### PR TITLE
Add systemd networkd to be build with smallos by default

### DIFF
--- a/conf/distro/smallos.conf
+++ b/conf/distro/smallos.conf
@@ -21,3 +21,6 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 
 EXTRA_IMAGE_FEATURES =+ " tools-sdk"
 EXTRA_IMAGE_FEATURES =+ " ssh-server-openssh"
+
+# Configure networkd by default on smallos distro
+PACKAGECONFIG_append_pn-systemd = " networkd"

--- a/conf/distro/smallos.conf
+++ b/conf/distro/smallos.conf
@@ -22,5 +22,8 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 EXTRA_IMAGE_FEATURES =+ " tools-sdk"
 EXTRA_IMAGE_FEATURES =+ " ssh-server-openssh"
 
+# Install avahi daemon for discovery
+IMAGE_INSTALL =+ " avahi-daemon"
+
 # Configure networkd by default on smallos distro
 PACKAGECONFIG_append_pn-systemd = " networkd"


### PR DESCRIPTION
networkd should be anabled by default since some of our image features depending on it

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
