### PR TITLE
libpcre: properly enable utf8

### DIFF
--- a/recipes-configure/libpcre/libpcre_%.bbappend
+++ b/recipes-configure/libpcre/libpcre_%.bbappend
@@ -1,0 +1,9 @@
+# libpcre_%.bbappend
+#
+# Configure to build with proper suppot to utf-8, required
+# by Soletta's string node types.
+
+EXTRA_OECONF += "\
+    --enable-utf8 \
+    --enable-unicode-properties \
+"


### PR DESCRIPTION
It requires --enable-utf8 and --enable-unicode-properties

Otherwise some string node types won't work fine, as
string/regexp-search

Signed-off-by: Bruno Dilly bruno.dilly@intel.com
