### PR TITLE
pcre: rename deprecated utf8 configure option

### DIFF
--- a/recipes-configure/libpcre/libpcre_%.bbappend
+++ b/recipes-configure/libpcre/libpcre_%.bbappend
@@ -4,6 +4,6 @@
 # by Soletta's string node types.
 
 EXTRA_OECONF += "\
-    --enable-utf8 \
+    --enable-utf \
     --enable-unicode-properties \
 "


### PR DESCRIPTION
According to libpcre configure.ac, --enable-utf8 is deprecated
and --enable-utf should be used instead.

Therefore, switch to --enable-utf.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
