### PR TITLE
Revert "libpcre: properly enable utf8"

### DIFF
--- a/recipes-configure/libpcre/libpcre_%.bbappend
+++ b/recipes-configure/libpcre/libpcre_%.bbappend
@@ -1,9 +1,0 @@
-# libpcre_%.bbappend
-#
-# Configure to build with proper suppot to utf-8, required
-# by Soletta's string node types.
-
-EXTRA_OECONF += "\
-    --enable-utf8 \
-    --enable-unicode-properties \
-"


### PR DESCRIPTION
oe-core master (commit 839eebceecf33d106592bab154481486533ece75)
enabled unicode-properties by default in libpcre.

Because of that change and the fact that meta-soletta's bbappend
for libpcre has --enable-utf8 we start to get a configure error
(both --enable-utf and --enable-utf8 are enabled).

Instead of updating the bbappend to fix the error, we can just
remove it since it's no longer needed.

This reverts commit 60d7a8cee19723f986b57d9fb0f2d315b7d00809.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
