### PR TITLE
Enable to execute Soletta C and FBP test cases in package test (ptest) framework

### DIFF
--- a/recipes-soletta/soletta/files/run-ptest
+++ b/recipes-soletta/soletta/files/run-ptest
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#SOLETTA_C_TEST_RUNNER=suite.py
+SOLETTA_FBP_TEST_RUNNER=run-fbp-tests
+
+echo "=== Run Soletta C test cases ==="
+C_TEST_PASS_COUNTER=0
+C_TEST_FAIL_COUNTER=0
+C_TEST_SKIP_COUNTER=0
+C_TEST_DIR="src/test"
+
+cd $C_TEST_DIR
+for tc in $(ls | grep -v ".log"); do
+    timeout 30 ./$tc
+    case $? in
+      0)
+        echo "PASS: $tc"
+        C_TEST_PASS_COUNTER=$((C_TEST_PASS_COUNTER+1))
+        ;;
+      124)
+        echo "FAIL: $tc"
+        echo "$tc timeout"
+        C_TEST_SKIP_COUNTER=$((C_TEST_SKIP_COUNTER+1))
+        ;;
+      *)
+        echo "FAIL: $tc"
+        echo "$tc return non-zero"
+        C_TEST_FAIL_COUNTER=$((C_TEST_FAIL_COUNTER+1))
+        ;;
+    esac
+done
+echo "Summary: Soletta C Test"
+echo "         Case PASS: $C_TEST_PASS_COUNTER"
+echo "         Case FAIL: $C_TEST_FAIL_COUNTER"
+cd -
+
+echo "=== Run Soletta fbp test cases ==="
+python $SOLETTA_FBP_TEST_RUNNER --runner "/usr/bin/sol-fbp-runner" --log "DEBUG" 
+

--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -10,7 +10,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
 PV = "1_beta16+git${SRCPV}"
 
-SRC_URI = "gitsm://github.com/solettaproject/soletta.git;protocol=git"
+SRC_URI = "gitsm://github.com/solettaproject/soletta.git;protocol=git \
+           file://run-ptest \
+          "
 SRCREV = "b3e725a94cdd3fa5db34c1aecc26bbc330dfdc81"
 
 S = "${WORKDIR}/git"
@@ -87,4 +89,19 @@ do_install() {
    ln -sf libsoletta.so ${WORKDIR}/image/usr/lib/libsoletta.so.0.0.1
    COMMIT_ID=`git --git-dir=${WORKDIR}/git/.git rev-parse --verify HEAD`
    echo "Soletta: $COMMIT_ID" > ${D}/usr/lib/soletta/soletta-image-hash
+}
+
+inherit ptest
+
+do_compile_ptest() {
+        oe_runmake TARGETCC="${CC}" TARGETAR="${AR}" "tests"
+}
+
+do_install_ptest () {
+        mkdir -p ${D}/${PTEST_PATH}/src
+        cp -rf ${S}/build/stage/test ${D}/${PTEST_PATH}/src/
+        cp -f ${S}/data/scripts/suite.py ${D}/${PTEST_PATH}
+        cp -rf ${S}/src/test-fbp ${D}/${PTEST_PATH}/src/
+        cp -f ${S}/tools/run-fbp-tests ${D}/${PTEST_PATH}
+
 }


### PR DESCRIPTION
package test (ptest) is convinient way to run unit test in yocto.
This patch is to enable Soletta C/FBP tests in ptest as well.
Referring to https://wiki.yoctoproject.org/wiki/Ptest for ptest format.
- new file "run-ptest":  ptest test execution entry
- modify file "soletta_git.bb": add contents for build and deploy case

Signed-off-by: Lei Yang lei.a.yang@intel.com
