### PR TITLE
Update Soletta and Soletta-Dev-App

### DIFF
--- a/recipes-soletta/dev-app/soletta-dev-app_git.bb
+++ b/recipes-soletta/dev-app/soletta-dev-app_git.bb
@@ -1,17 +1,17 @@
 DESCRIPTION = "Soletta Development Application"
 DEPENDS = "nodejs-native"
 RDEPENDS_${PN} = "soletta nodejs systemd graphviz libmicrohttpd avahi-daemon bash git"
-LICENSE = "BSD-3-Clause"
-PV = "1_beta4+git${SRCPV}"
+LICENSE = "Apache-2.0"
+PV = "1_beta6+git${SRCPV}"
 
-LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=dbf9699ab0f60ec50f52ce70fcd07caf"
+LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
 
 SRC_URI = "git://git@github.com/solettaproject/soletta-dev-app.git;protocol=https \
            file://soletta-dev-app.service \
            file://soletta-dev-app-mac.sh \
            file://soletta-dev-app-avahi-discover.service \
 "
-SRCREV = "5389b18efb75d21bcc593bb059917af27cb82b4b"
+SRCREV = "f34b40c6a90aaf43bbf2cd31b8371170f2becd66"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-soletta/images/soletta-image.bb
+++ b/recipes-soletta/images/soletta-image.bb
@@ -3,7 +3,6 @@
 #
 
 SUMMARY = "A console-only image with built-in soletta"
-LICENSE = "BSD"
 
 IMAGE_INSTALL += "packagegroup-core-boot ${ROOTFS_PKGMANAGE_BOOTSTRAP} ${CORE_IMAGE_EXTRA_INSTALL} kernel-modules"
 

--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -5,12 +5,12 @@
 DESCRIPTION = "Soletta library and modules"
 SECTION = "examples"
 DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://COPYING;md5=53eeaddf328b23e2355816e257450eaa"
-PV = "1_beta15+git${SRCPV}"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
+PV = "1_beta16+git${SRCPV}"
 
 SRC_URI = "gitsm://github.com/solettaproject/soletta.git;protocol=git"
-SRCREV = "2bbe44194e563c4f1d6049ce4d5094760d25b21e"
+SRCREV = "b3e725a94cdd3fa5db34c1aecc26bbc330dfdc81"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Change project license from BSD-3 clause to Apache 2.0

The Soletta project chose to switch to Apache 2.0 to ensure that all
contributors explicitly grant the right to use any patents in their
contributions.  This avoids the possibility of a contributor
subsequently using patents to threaten the Soletta community or the
users and distributors of Soletta-based devices.  IoT is a rapidly
developing area, with many people filing patents and attempting to claim
territory; this change helps us maintain and protect our Open Source
project and community.

Other IoT projects have also chosen the Apache 2.0 license for similar
reasons, including IoTivity and the recently released Zephyr OS.

Soletta extra changelog:
- Fixes on HTTP implementation regarding IPv6
- Fixed pin mux issue when using Edison without the arduino board
- Single node support - so it’s possible to have a single node without
  an associated flow. Useful when you need to access a component,
  send packets to its input ports manually and be notified when
  it's sending packets on its output ports.
- Support running Soletta using Zephyr’s nanokernel (not only microkernel)
- Reduced memory consumption by CoAP - LWM2M samples are running fine on RIOT
- Increased amount of node types supported by GTK (simulation)

Signed-off-by: Bruno Dilly bruno.dilly@intel.com
