### PR TITLE
soletta: Add mqtt build support

### DIFF
--- a/recipes-modules/mosquitto/files/build.patch
+++ b/recipes-modules/mosquitto/files/build.patch
@@ -1,0 +1,88 @@
+From ebd7c8e548e9b8e096ee4c390173db9a701f2604 Mon Sep 17 00:00:00 2001
+From: Bruno Bottazzini <bruno.bottazzini@intel.com>
+Date: Wed, 23 Mar 2016 11:18:26 -0300
+Subject: [PATCH] build
+
+Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>
+---
+ client/Makefile  | 4 ++--
+ config.mk        | 2 +-
+ lib/Makefile     | 2 +-
+ lib/cpp/Makefile | 2 +-
+ src/Makefile     | 4 ++--
+ 5 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/client/Makefile b/client/Makefile
+index bd65355..4e5a640 100644
+--- a/client/Makefile
++++ b/client/Makefile
+@@ -24,8 +24,8 @@ client_shared.o : client_shared.c client_shared.h
+ 
+ install : all
+ 	$(INSTALL) -d ${DESTDIR}$(prefix)/bin
+-	$(INSTALL) -s --strip-program=${CROSS_COMPILE}${STRIP} mosquitto_pub ${DESTDIR}${prefix}/bin/mosquitto_pub
+-	$(INSTALL) -s --strip-program=${CROSS_COMPILE}${STRIP} mosquitto_sub ${DESTDIR}${prefix}/bin/mosquitto_sub
++	$(INSTALL) mosquitto_pub ${DESTDIR}${prefix}/bin/mosquitto_pub
++	$(INSTALL) mosquitto_sub ${DESTDIR}${prefix}/bin/mosquitto_sub
+ 
+ uninstall :
+ 	-rm -f ${DESTDIR}${prefix}/bin/mosquitto_pub
+diff --git a/config.mk b/config.mk
+index c0f175f..3427b83 100644
+--- a/config.mk
++++ b/config.mk
+@@ -240,7 +240,7 @@ ifeq ($(WITH_DOCS),yes)
+ endif
+ 
+ INSTALL?=install
+-prefix=/usr/local
++prefix=/usr
+ mandir=${prefix}/share/man
+ localedir=${prefix}/share/locale
+ STRIP?=strip
+diff --git a/lib/Makefile b/lib/Makefile
+index 825fcea..9b7c05c 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -25,7 +25,7 @@ all : libmosquitto.so.${SOVERSION} libmosquitto.a
+ 
+ install : all
+ 	$(INSTALL) -d ${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/
+-	$(INSTALL) -s --strip-program=${CROSS_COMPILE}${STRIP} libmosquitto.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so.${SOVERSION}
++	$(INSTALL) libmosquitto.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so.${SOVERSION}
+ 	ln -sf libmosquitto.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so
+ 	$(INSTALL) -d ${DESTDIR}${prefix}/include/
+ 	$(INSTALL) mosquitto.h ${DESTDIR}${prefix}/include/mosquitto.h
+diff --git a/lib/cpp/Makefile b/lib/cpp/Makefile
+index 8b627d3..cdb2923 100644
+--- a/lib/cpp/Makefile
++++ b/lib/cpp/Makefile
+@@ -10,7 +10,7 @@ all : libmosquittopp.so.${SOVERSION}
+ 
+ install : all
+ 	$(INSTALL) -d ${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/
+-	$(INSTALL) -s --strip-program=${CROSS_COMPILE}${STRIP} libmosquittopp.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so.${SOVERSION}
++	$(INSTALL) libmosquittopp.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so.${SOVERSION}
+ 	ln -sf libmosquittopp.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so
+ 	$(INSTALL) -d ${DESTDIR}${prefix}/include/
+ 	$(INSTALL) mosquittopp.h ${DESTDIR}${prefix}/include/mosquittopp.h
+diff --git a/src/Makefile b/src/Makefile
+index 2cfb7d4..9a97644 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -103,10 +103,10 @@ mosquitto_passwd.o : mosquitto_passwd.c
+ 
+ install : all
+ 	$(INSTALL) -d ${DESTDIR}$(prefix)/sbin
+-	$(INSTALL) -s --strip-program=${CROSS_COMPILE}${STRIP} mosquitto ${DESTDIR}${prefix}/sbin/mosquitto
++	$(INSTALL) mosquitto ${DESTDIR}${prefix}/sbin/mosquitto
+ 	$(INSTALL) mosquitto_plugin.h ${DESTDIR}${prefix}/include/mosquitto_plugin.h
+ ifeq ($(WITH_TLS),yes)
+-	$(INSTALL) -s --strip-program=${CROSS_COMPILE}${STRIP} mosquitto_passwd ${DESTDIR}${prefix}/bin/mosquitto_passwd
++	$(INSTALL) mosquitto_passwd ${DESTDIR}${prefix}/bin/mosquitto_passwd
+ endif
+ 
+ uninstall :
+-- 
+2.7.1
+

--- a/recipes-modules/mosquitto/files/mosquitto.service
+++ b/recipes-modules/mosquitto/files/mosquitto.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mosquitto - lightweight server implementation of the MQTT and MQTT-SN protocols
+ConditionPathExists=/etc/mosquitto/mosquitto.conf
+After=network.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/rm -f /var/run/mosquitto.pid
+ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
+ExecReload=/bin/kill -HUP $MAINPID
+PIDFile=/var/run/mosquitto.pid
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-modules/mosquitto/mosquitto_1.4.bb
+++ b/recipes-modules/mosquitto/mosquitto_1.4.bb
@@ -1,0 +1,55 @@
+SUMMARY = "Open source MQTT v3.1 implemention"
+DESCRIPTION = "Mosquitto is an open source (BSD licensed) message broker that implements the MQ Telemetry Transport protocol version 3.1. MQTT provides a lightweight method of carrying out messaging using a publish/subscribe model. "
+HOMEPAGE = "http://mosquitto.org/"
+SECTION = "console/network"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=62ddc846179e908dc0c8efec4a42ef20"
+
+DEPENDS = "openssl util-linux"
+
+PR = "r0"
+
+SRC_URI = "http://mosquitto.org/files/source/mosquitto-${PV}.tar.gz \
+           file://build.patch \
+           file://mosquitto.service \
+"
+
+SRC_URI[md5sum] = "cd879f5964311501ba8e2275add71484"
+SRC_URI[sha256sum] = "591f3adcb6ed92c01f7ace1c878af728b797fe836892535620aa6106f42dbcc6"
+
+
+do_install() {
+    oe_runmake install DESTDIR=${D}
+    install -d ${D}${libbir}
+    install -m 0644 lib/libmosquitto.a ${D}${libdir}/
+
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/mosquitto.service ${D}${systemd_unitdir}/system/
+
+    cp ${D}${sysconfdir}/mosquitto/mosquitto.conf.example ${D}${sysconfdir}/mosquitto/mosquitto.conf
+    sed 's/#user mosquitto/user root/' -i ${D}${sysconfdir}/mosquitto/mosquitto.conf
+}
+
+PACKAGES += "libmosquitto1 libmosquittopp1 ${PN}-clients ${PN}-python"
+
+FILES_${PN} = "${sbindir}/mosquitto \
+               ${bindir}/mosquitto_passwd \
+               ${sysconfdir} \
+               ${systemd_unitdir}/system/mosquitto.service \
+"
+
+FILES_libmosquitto1 = "${libdir}/libmosquitto.so.1"
+
+FILES_libmosquittopp1 = "${libdir}/libmosquittopp.so.1"
+
+FILES_${PN}-clients = "${bindir}/mosquitto_pub \
+                       ${bindir}/mosquitto_sub \
+"
+
+FILES_${PN}-staticdev += "${libdir}/libmosquitto.a"
+
+FILES_${PN}-python = "/usr/lib/python2.7/site-packages"
+
+inherit systemd
+
+SYSTEMD_SERVICE_${PN} = "mosquitto.service"

--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -4,7 +4,7 @@
 
 DESCRIPTION = "Soletta library and modules"
 SECTION = "examples"
-DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl libmicrohttpd"
+DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl libmicrohttpd mosquitto"
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd','',d)}"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"


### PR DESCRIPTION
Soletta depends on lib mosquitto (Version >= 1.4) to build with mqtt support.

This patch adds the required recipe and the depends in Soletta recipe.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
