### PR TITLE
soletta: update to 1_beta18

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -8,12 +8,12 @@ DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl libmicr
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd','',d)}"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
-PV = "1_beta17+git${SRCPV}"
+PV = "1_beta18+git${SRCPV}"
 
 SRC_URI = "gitsm://github.com/solettaproject/soletta.git;protocol=git \
            file://run-ptest \
           "
-SRCREV = "5daa00eadbe275dbb696a749f22fd319e39d877f"
+SRCREV = "97091af414193c37278ba5ff88c70c596eecd7ea"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Idea here is that this one would be the Soletta version
for Ostro V1. It would be nice to have mosquito
PR merged and i2c-dev issue solved as well.

There's a new Soletta version with the following changes:
- Changes on CoAP implementation improving memory-efficiency
- Provide node types for a lot of OIC resources data models
- Many changes on LWM2M API in order to have a more consistent
  API for all communication protocols
- Added API to server side events on http-server with samples.
  It was supported on http-client as well.
- Updated GPIO implementation for Zephyr considering changes on its API
- Implemented sol-network and sol-socket for Zephyr
- GPIO, AIO, PWM and UART bindings for Node.js
- Added web inspector to sol-fbp-runner
- Dependencies of samples were fixed
- RIOT I/O implementation was updated to match API changes
- Fix OIC to deal with cases where IPv4 isn't enabled
