### PR TITLE
[Do Not Merge] soletta: Add Node.js bindings to soletta package

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -4,7 +4,7 @@
 
 DESCRIPTION = "Soletta library and modules"
 SECTION = "examples"
-DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl libmicrohttpd mosquitto"
+DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl libmicrohttpd mosquitto nodejs"
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd','',d)}"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
@@ -21,6 +21,7 @@ inherit cml1 python3native
 
 PACKAGES = " \
          ${PN}-staticdev \
+         ${PN}-nodejs \
          ${PN}-dev \
          ${PN}-dbg \
          ${PN} \
@@ -48,6 +49,10 @@ FILES_${PN} = " \
             ${bindir}/sol* \
             ${libdir}/libsoletta.so* \
             ${libdir}/soletta/soletta-image-hash \
+"
+
+FILES_${PN}-nodejs = " \
+                   ${libdir}/node_modules/soletta \
 "
 
 # Setup what PACKAGES should be installed by default.
@@ -78,7 +83,59 @@ do_configure_prepend() {
    export TARGETAR="${AR}"
 }
 
+do_compile_prepend() {
+   export CFLAGS="$CFLAGS -fPIC"
+   export CXXFLAGS="$CXXFLAGS -fPIC"
+}
+
 do_compile() {
+   # changing the home directory to the working directory, the .npmrc will be created in this directory
+   export HOME=${WORKDIR}
+
+   # does not build dev packages
+   npm config set dev false
+
+   # access npm registry using http
+   npm set strict-ssl false
+   npm config set registry http://registry.npmjs.org/
+
+   # configure http proxy if neccessary
+   if [ -n "${http_proxy}" ]; then
+       npm config set proxy ${http_proxy}
+       NODE_GYP_PROXY="--proxy=${http_proxy}"
+   fi
+   if [ -n "${HTTP_PROXY}" ]; then
+       npm config set proxy ${HTTP_PROXY}
+       NODE_GYP_PROXY="--proxy=${HTTP_PROXY}"
+   fi
+
+   # configure cache to be in working directory
+   npm set cache ${WORKDIR}/npm_cache
+
+   # clear local cache prior to each compile
+   npm cache clear
+
+   case ${TARGET_ARCH} in
+       i?86) targetArch="ia32"
+           ;;
+       x86_64) targetArch="x64"
+           ;;
+       arm) targetArch="arm"
+           ;;
+       mips) targetArch="mips"
+           ;;
+       sparc) targetArch="sparc"
+           ;;
+       *) echo "unknown architecture"
+          exit 1
+           ;;
+   esac
+
+   # Export needed variables to build Node.js bindings
+   export NODE_GYP="${STAGING_DIR_NATIVE}/${libdir}/node_modules/npm/bin/node-gyp-bin/node-gyp --arch=${targetArch} ${NODE_GYP_PROXY}"
+   # TODO: Remove this once the bindings are enabled by default
+   export USE_NODEJS=1
+
    oe_runmake CFLAGS="--sysroot=${STAGING_DIR_TARGET} -pthread -lpcre" TARGETCC="${CC}" TARGETAR="${AR}"
 }
 
@@ -89,6 +146,9 @@ do_install() {
    ln -sf libsoletta.so ${WORKDIR}/image/usr/lib/libsoletta.so.0.0.1
    COMMIT_ID=`git --git-dir=${WORKDIR}/git/.git rev-parse --verify HEAD`
    echo "Soletta: $COMMIT_ID" > ${D}/usr/lib/soletta/soletta-image-hash
+
+   # Remove nan module as it is not needed.
+   rm -rf ${WORKDIR}/image/usr/lib/node_modules/soletta/node_modules/nan
 }
 
 inherit ptest


### PR DESCRIPTION
This patch exports the needed variables to build Node.js
bindings and add them to the soletta package.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
