### PR TITLE
soletta: Add Node.js bindings to soletta package

### DIFF
--- a/recipes-soletta/soletta/files/0027-Node.js-bindings-Add-the-JS-APIs-to-the-root-and-the.patch
+++ b/recipes-soletta/soletta/files/0027-Node.js-bindings-Add-the-JS-APIs-to-the-root-and-the.patch
@@ -1,0 +1,113 @@
+From a259e48e8845a75cc8fb9723c3e3254828ac107f Mon Sep 17 00:00:00 2001
+From: Gabriel Schulhof <gabriel.schulhof@intel.com>
+Date: Tue, 12 Apr 2016 10:11:04 +0300
+Subject: [PATCH 27/50] Node.js bindings: Add the JS APIs to the root and the
+ package to the sysroot
+
+Fixes gh-1826
+Closes gh-1875
+
+Signed-off-by: Gabriel Schulhof <gabriel.schulhof@intel.com>
+---
+ binding.gyp                  | 17 ++++++++++++++++-
+ package.json                 |  2 +-
+ tools/build/Makefile.targets | 10 +++++++++-
+ tools/build/Makefile.vars    |  1 +
+ 4 files changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/binding.gyp b/binding.gyp
+index 28357e5..7722a6f 100644
+--- a/binding.gyp
++++ b/binding.gyp
+@@ -38,6 +38,21 @@
+ 					} ]
+ 				},
+ 				{
++					"target_name": "copyapis",
++					"type": "none",
++					"actions": [ {
++						"action_name": "copyapis",
++						"message": "Copying JS APIs",
++						"inputs": [ "./bindings/nodejs/lib" ],
++						"outputs": [ "" ],
++						"action": [
++							"sh",
++							"-c",
++							"cp -a ./bindings/nodejs/lib/* ."
++						]
++					} ]
++				},
++				{
+ 					"target_name": "soletta",
+ 					"includes": [
+ 						"bindings/nodejs/generated/nodejs-bindings-sources.gyp"
+@@ -50,7 +65,7 @@
+ 						"OTHER_CFLAGS": [ '<!@(echo "${SOLETTA_CFLAGS}")' ]
+ 					},
+ 					"libraries": [ '<!@(echo "${SOLETTA_LIBS}")' ],
+-					"dependencies": [ "collectbindings" ]
++					"dependencies": [ "collectbindings", "copyapis" ]
+ 				}
+ 			]
+ 		} ]
+diff --git a/package.json b/package.json
+index 3cde925..a249841 100644
+--- a/package.json
++++ b/package.json
+@@ -27,12 +27,12 @@
+   "homepage": "https://github.com/solettaproject/soletta#readme",
+   "dependencies": {
+     "bindings": "^1.2.1",
++    "lodash": "^4.3.0",
+     "nan": "^2.1.0"
+   },
+   "devDependencies": {
+     "async": "^1.5.2",
+     "glob": "^6.0.4",
+-    "lodash": "^4.3.0",
+     "qunitjs": "^1.21.0",
+     "uuid": "^2.0.1",
+     "yargs": "^4.2.0"
+diff --git a/tools/build/Makefile.targets b/tools/build/Makefile.targets
+index 073294f..c3004eb 100644
+--- a/tools/build/Makefile.targets
++++ b/tools/build/Makefile.targets
+@@ -200,7 +200,7 @@ bins-out += bindings-nodejs
+ NODE_GYP ?= $(NODE_GYP_PATH)/node-gyp
+ 
+ bindings-nodejs: $(SOL_LIB_OUTPUT)
+-	$(Q) $(NODEJS_NPM) install --ignore-scripts
++	$(Q) $(NODEJS_NPM) install --ignore-scripts --production
+ 
+ 	$(Q) \
+ 		SOL_CONFIG_OIC=$(OIC) \
+@@ -216,6 +216,14 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
+ 		export SOLETTA_LIBS="$(FIND_LIBRARY_LDFLAGS)"; \
+ 			$(NODE_GYP) configure && $(NODE_GYP) build )
+ 
++	$(Q) mkdir -p $(build_nodejs_bindingsdir)
++	$(Q) cp -a *js package.json $(build_nodejs_bindingsdir)
++	$(Q) mkdir -p $(build_nodejs_bindingsdir)/build
++	$(Q) cp $$(find build -type f -name soletta.node | head -n 1) \
++		$(build_nodejs_bindingsdir)/build
++	$(Q) mkdir -p $(build_nodejs_bindingsdir)/node_modules
++	$(Q) cp -a ./node_modules/* $(build_nodejs_bindingsdir)/node_modules
++
+ PHONY += bindings-nodejs
+ 
+ check-bindings-nodejs: bindings-nodejs
+diff --git a/tools/build/Makefile.vars b/tools/build/Makefile.vars
+index 6eebeac..1f687ba 100644
+--- a/tools/build/Makefile.vars
++++ b/tools/build/Makefile.vars
+@@ -144,6 +144,7 @@ build_datadir := $(build_sysroot)$(SOL_DATADIR)
+ build_flowdatadir := $(build_sysroot)$(SOL_FLOW_DATADIR)
+ build_gdbautoload := $(build_sysroot)$(DATADIR)gdb/auto-load/
+ build_docdir := $(build_stagedir)doc/
++build_nodejs_bindingsdir := $(build_libdir)/node_modules/soletta/
+ 
+ PACKAGE_DOCNAME := soletta-$(VERSION)-doc
+ build_doxygendir := $(build_docdir)doxygen/
+-- 
+1.9.1
+

--- a/recipes-soletta/soletta/files/0028-Build-Install-devDependencies-upon-make-check.patch
+++ b/recipes-soletta/soletta/files/0028-Build-Install-devDependencies-upon-make-check.patch
@@ -1,0 +1,38 @@
+From 13fe5d1a4c93fe065e6e3d0cd9cbb555663aa7e3 Mon Sep 17 00:00:00 2001
+From: Gabriel Schulhof <gabriel.schulhof@intel.com>
+Date: Wed, 20 Apr 2016 18:15:28 +0300
+Subject: [PATCH 03/10] Build: Install devDependencies upon make check
+
+Closes gh-1916
+
+Signed-off-by: Gabriel Schulhof <gabriel.schulhof@intel.com>
+---
+ tools/build/Makefile.targets | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/tools/build/Makefile.targets b/tools/build/Makefile.targets
+index 51393d8..93b8acb 100644
+--- a/tools/build/Makefile.targets
++++ b/tools/build/Makefile.targets
+@@ -220,7 +220,7 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
+ 	$(Q) mkdir -p $(build_nodejs_bindingsdir)
+ 	$(Q) cp -a *js package.json $(build_nodejs_bindingsdir)
+ 	$(Q) mkdir -p $(build_nodejs_bindingsdir)/build
+-	$(Q) cp $$(find build -type f -name soletta.node | head -n 1) \
++	$(Q) cp $$(find build -type f -name soletta.node | grep -v 'soletta_sysroot' | head -n 1) \
+ 		$(build_nodejs_bindingsdir)/build
+ 	$(Q) mkdir -p $(build_nodejs_bindingsdir)/node_modules
+ 	$(Q) cp -a ./node_modules/* $(build_nodejs_bindingsdir)/node_modules
+@@ -228,7 +228,8 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
+ PHONY += bindings-nodejs
+ 
+ check-bindings-nodejs: bindings-nodejs
+-	node $(NODEJS_ROOT)/tests/suite.js --ldPreload="$(LIB_ASAN_PATH)"
++	$(Q) $(NODEJS_NPM) install --ignore-scripts
++	$(Q) $(NODEJS) $(NODEJS_ROOT)/tests/suite.js --ldPreload="$(LIB_ASAN_PATH)"
+ PHONY += check-bindings-nodejs
+ 
+ endif #neq($(USE_NODEJS),)
+-- 
+1.9.1
+

--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -4,7 +4,7 @@
 
 DESCRIPTION = "Soletta library and modules"
 SECTION = "examples"
-DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl libmicrohttpd mosquitto"
+DEPENDS = "glib-2.0 libpcre pkgconfig python3-jsonschema-native icu curl libmicrohttpd mosquitto nodejs"
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd','',d)}"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
@@ -28,6 +28,7 @@ inherit cml1 python3native
 
 PACKAGES = " \
          ${PN}-staticdev \
+         ${PN}-nodejs \
          ${PN}-dev \
          ${PN}-dbg \
          ${PN} \
@@ -58,6 +59,10 @@ FILES_${PN} = " \
             ${libdir}/soletta/soletta-image-hash \
 "
 
+FILES_${PN}-nodejs = " \
+                   ${libdir}/node_modules/soletta \
+"
+
 # Setup what PACKAGES should be installed by default.
 # If a package should not being installed, use BAD_RECOMMENDS.
 RRECOMMENDS_${PN} = "\
@@ -86,7 +91,57 @@ do_configure_prepend() {
    export TARGETAR="${AR}"
 }
 
+do_compile_prepend() {
+   export CFLAGS="$CFLAGS -fPIC"
+   export CXXFLAGS="$CXXFLAGS -fPIC"
+}
+
 do_compile() {
+   # changing the home directory to the working directory, the .npmrc will be created in this directory
+   export HOME=${WORKDIR}
+
+   # does not build dev packages
+   npm config set dev false
+
+   # access npm registry using http
+   npm set strict-ssl false
+   npm config set registry http://registry.npmjs.org/
+
+   # configure http proxy if neccessary
+   if [ -n "${http_proxy}" ]; then
+       npm config set proxy ${http_proxy}
+       NODE_GYP_PROXY="--proxy=${http_proxy}"
+   fi
+   if [ -n "${HTTP_PROXY}" ]; then
+       npm config set proxy ${HTTP_PROXY}
+       NODE_GYP_PROXY="--proxy=${HTTP_PROXY}"
+   fi
+
+   # configure cache to be in working directory
+   npm set cache ${WORKDIR}/npm_cache
+
+   # clear local cache prior to each compile
+   npm cache clear
+
+   case ${TARGET_ARCH} in
+       i?86) targetArch="ia32"
+           ;;
+       x86_64) targetArch="x64"
+           ;;
+       arm) targetArch="arm"
+           ;;
+       mips) targetArch="mips"
+           ;;
+       sparc) targetArch="sparc"
+           ;;
+       *) echo "unknown architecture"
+          exit 1
+           ;;
+   esac
+
+   # Export needed variables to build Node.js bindings
+   export NODE_GYP="${STAGING_DIR_NATIVE}/${libdir}/node_modules/npm/bin/node-gyp-bin/node-gyp --arch=${targetArch} ${NODE_GYP_PROXY}"
+
    oe_runmake CFLAGS="--sysroot=${STAGING_DIR_TARGET} -pthread -lpcre" TARGETCC="${CC}" TARGETAR="${AR}"
 }
 
@@ -97,6 +152,9 @@ do_install() {
    ln -sf libsoletta.so ${WORKDIR}/image/usr/lib/libsoletta.so.0.0.1
    COMMIT_ID=`git --git-dir=${WORKDIR}/git/.git rev-parse --verify HEAD`
    echo "Soletta: $COMMIT_ID" > ${D}/usr/lib/soletta/soletta-image-hash
+
+   # Remove nan module as it is not needed.
+   rm -rf ${WORKDIR}/image/usr/lib/node_modules/soletta/node_modules/nan
 }
 
 do_install_append() {

--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -13,6 +13,8 @@ PV = "1_beta18+git${SRCPV}"
 SRC_URI = "gitsm://github.com/solettaproject/soletta.git;protocol=git \
            file://run-ptest \
            file://0013-lib-sol-iio-release-buffer-on-sol_iio_close.patch \
+           file://0027-Node.js-bindings-Add-the-JS-APIs-to-the-root-and-the.patch \
+           file://0028-Build-Install-devDependencies-upon-make-check.patch \
            file://0047-oic-gen-fix-rep_vec-issue.patch \
            file://0048-oic-gen-ReadOnly-props-from-imported-json-objs-were-.patch \
            file://0049-oic-gen-Don-t-add-client-to_repr_vec-when-all-props-.patch \


### PR DESCRIPTION
This patch exports the needed variables to build Node.js bindings and add them to the soletta package.

[1] This
[2] https://github.com/ostroproject/meta-ostro/pull/115 (Enable bindings by default)
[3] https://github.com/ostroproject/meta-iot-web/pull/10 (Add soletta-nodejs package to Node.js runtime package group)

Test build with all these changes: https://ostroproject.org/jenkins/job/ostro-os_pull-requests/412/

This replaces #63 

Changes between #63 and this: 
Backporting couple of bindings installation patches that required for Ostro.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
