### PR TITLE
Replace npm installation to use the fetcher from Yocto

### DIFF
--- a/recipes-modules/bower/bower_1.7.9.bb
+++ b/recipes-modules/bower/bower_1.7.9.bb
@@ -1,0 +1,5 @@
+SRC_URI = "npm://registry.npmjs.org;name=${PN};version=${PV}"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e273de0d9430b4e4a74446f00e19ac54"
+
+inherit npm

--- a/recipes-soletta/dev-app/soletta-dev-app_0.0.7.bb
+++ b/recipes-soletta/dev-app/soletta-dev-app_0.0.7.bb
@@ -1,26 +1,22 @@
 DESCRIPTION = "Soletta Development Application"
-DEPENDS = "nodejs-native"
+DEPENDS = "nodejs-native bower"
 RDEPENDS_${PN} = "soletta nodejs systemd graphviz libmicrohttpd avahi-daemon bash git"
 LICENSE = "Apache-2.0"
-PV = "1_beta8+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
 
-SRC_URI = "git://git@github.com/solettaproject/soletta-dev-app.git;protocol=https \
+SRC_URI = "npm://registry.npmjs.org;name=${PN};version=${PV} \
            file://soletta-dev-app.service \
            file://soletta-dev-app-mac.sh \
            file://soletta-dev-app-avahi-discover.service \
 "
-SRCREV = "f9f011a47394bcb0c04b4e0439a20e56e0f69ce1"
-
-S = "${WORKDIR}/git"
 
 # We provide only one package
 PACKAGES = " \
 	${PN} \
 "
 
-inherit systemd
+inherit npm systemd
 
 INSTALLATION_PATH = "/opt/"
 SYSTEMD_PATH = "${systemd_unitdir}/system/"
@@ -37,62 +33,20 @@ FILES_${PN} += " \
 
 SYSTEMD_SERVICE_${PN} = "soletta-dev-app-server.service soletta-dev-app-avahi-discover.service"
 
-do_compile() {
+do_configure_prepend() {
+  #Installing client-side libs
+  if [ -n "${http_proxy}" ]; then
+     export bower_https_proxy=${http_proxy}
+  fi
+  if [ -n "${HTTP_PROXY}" ]; then
+    export bower_https_proxy=${HTTP_PROXY}
+  fi
 
-    # changing the home directory to the working directory, the .npmrc will be created in this directory
-    export HOME=${WORKDIR}
-
-    # does not build dev packages
-    npm config set dev false
-
-    # access npm registry using http
-    npm set strict-ssl false
-    npm config set registry http://registry.npmjs.org/
-
-    # configure http proxy if neccessary
-    if [ -n "${http_proxy}" ]; then
-        npm config set proxy ${http_proxy}
-        export bower_https_proxy=${http_proxy}
-    fi
-    if [ -n "${HTTP_PROXY}" ]; then
-        npm config set proxy ${HTTP_PROXY}
-        export bower_https_proxy=${HTTP_PROXY}
-    fi
-
-    # configure cache to be in working directory
-    npm set cache ${WORKDIR}/npm_cache
-
-    # clear local cache prior to each compile
-    npm cache clear
-
-    case ${TARGET_ARCH} in
-        i?86) targetArch="ia32"
-            echo "targetArch = 32"
-            ;;
-        x86_64) targetArch="x64"
-            echo "targetArch = 64"
-            ;;
-        arm) targetArch="arm"
-            ;;
-        mips) targetArch="mips"
-            ;;
-        sparc) targetArch="sparc"
-            ;;
-        *) echo "unknown architecture"
-           exit 1
-            ;;
-    esac
-
-    npm install --arch=${targetArch} --production --verbose -g bower@v1.7.9
-
-    # compile and install node modules in source directory
-    npm --arch=${targetArch} --production --verbose install
-
-    bower -V install
+  bower -V install
 }
 
 do_install() {
-  install -d ${D}{INSTALLATION_PATH}
+  install -d ${D}${INSTALLATION_PATH}
   install -d ${D}${INSTALLATION_PATH}soletta-dev-app
   cp -r ${S}/* ${D}${INSTALLATION_PATH}soletta-dev-app
 
@@ -110,6 +64,6 @@ do_install() {
   #Configure services that will set MAC address to Soletta Dev-App name
   install -m 0664 ${WORKDIR}/soletta-dev-app-avahi-discover.service ${D}${SYSTEMD_PATH}
 
- #Install set MAC address script
- install  -m 0755 ${WORKDIR}/soletta-dev-app-mac.sh ${D}${INSTALLATION_PATH}soletta-dev-app/scripts/
+  #Install set MAC address script
+  install  -m 0755 ${WORKDIR}/soletta-dev-app-mac.sh ${D}${INSTALLATION_PATH}soletta-dev-app/scripts/
 }


### PR DESCRIPTION
This move the source downloads to the do_fetch phase instead of do_compile.

Also, the build system could cache the sources, reducing the number of places
where the download could go wrong.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
