### PR TITLE
Revert soletta-dev-app recipe to use standlone version instead of npm

### DIFF
--- a/recipes-soletta/dev-app/soletta-dev-app_git.bb
+++ b/recipes-soletta/dev-app/soletta-dev-app_git.bb
@@ -1,19 +1,19 @@
 DESCRIPTION = "Soletta Development Application"
-DEPENDS = "nodejs-native"
 RDEPENDS_${PN} = "soletta nodejs systemd graphviz libmicrohttpd avahi-daemon bash git"
 LICENSE = "Apache-2.0"
-PV = "1_beta8+git${SRCPV}"
+
+PV = "1_beta8"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
-
-SRC_URI = "git://git@github.com/solettaproject/soletta-dev-app.git;protocol=https \
+SRC_URI[md5sum] = "557e80c99ac34d1c55dcb18423a1c308"
+SRC_URI[sha256sum] = "141a3e6df771d64fcb46c41489837b938995c4d0b7997e384232cc7d11303fbf"
+SRC_URI = "https://github.com/solettaproject/soletta-dev-app/releases/download/v${PV}/soletta-dev-app_standalone_v${PV}.tar.gz;protocol=archive \
            file://soletta-dev-app.service \
            file://soletta-dev-app-mac.sh \
            file://soletta-dev-app-avahi-discover.service \
 "
-SRCREV = "f9f011a47394bcb0c04b4e0439a20e56e0f69ce1"
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/${PN}"
 
 # We provide only one package
 PACKAGES = " \
@@ -36,60 +36,6 @@ FILES_${PN} += " \
 "
 
 SYSTEMD_SERVICE_${PN} = "soletta-dev-app-server.service soletta-dev-app-avahi-discover.service"
-
-do_compile() {
-
-    # changing the home directory to the working directory, the .npmrc will be created in this directory
-    export HOME=${WORKDIR}
-
-    # does not build dev packages
-    npm config set dev false
-
-    # access npm registry using http
-    npm set strict-ssl false
-    npm config set registry http://registry.npmjs.org/
-
-    # configure http proxy if neccessary
-    if [ -n "${http_proxy}" ]; then
-        npm config set proxy ${http_proxy}
-        export bower_https_proxy=${http_proxy}
-    fi
-    if [ -n "${HTTP_PROXY}" ]; then
-        npm config set proxy ${HTTP_PROXY}
-        export bower_https_proxy=${HTTP_PROXY}
-    fi
-
-    # configure cache to be in working directory
-    npm set cache ${WORKDIR}/npm_cache
-
-    # clear local cache prior to each compile
-    npm cache clear
-
-    case ${TARGET_ARCH} in
-        i?86) targetArch="ia32"
-            echo "targetArch = 32"
-            ;;
-        x86_64) targetArch="x64"
-            echo "targetArch = 64"
-            ;;
-        arm) targetArch="arm"
-            ;;
-        mips) targetArch="mips"
-            ;;
-        sparc) targetArch="sparc"
-            ;;
-        *) echo "unknown architecture"
-           exit 1
-            ;;
-    esac
-
-    npm install --arch=${targetArch} --production --verbose -g bower@v1.7.9
-
-    # compile and install node modules in source directory
-    npm --arch=${targetArch} --production --verbose install
-
-    bower -V install
-}
 
 do_install() {
   install -d ${D}{INSTALLATION_PATH}


### PR DESCRIPTION
npm faling by downloading incompleted files resulting in wrong shasum.
As it is possible to see here: https://github.com/npm/npm/issues/2701

To workaround this problem, we reverted the recipe to use the standalone
version of Soletta Dev-App. It will contain all needed package to run
without needing to run the command npm.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
