### PR TITLE
soletta_git.bb: Add conditional deps to graphics libs

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -29,6 +29,9 @@ PACKAGES = " \
          ${PN} \
 "
 
+PACKAGECONFIG ??= "x11"
+PACKAGECONFIG[x11] = ",,cairo atk gtk+3 gdk-pixbuf pango,"
+
 FILES_${PN}-staticdev = " \
                       ${libdir}/libsoletta.a \
 "


### PR DESCRIPTION
When the feature x11 is enabled soletta starts to link to libs
like GTK and cairo. Add those libs to the list of build
dependencies in case x11 is enabled.

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com
