### PR TITLE
Fix: QA phase errors

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -77,6 +77,7 @@ RDEPENDS_${PN} = " \
 # do_package_qa tells soletta rdepends on soletta-dev
 # maybe an non-obvious implicit rule implied by yocto
 INSANE_SKIP_${PN} += "dev-deps file-rdeps"
+INSANE_SKIP_${PN}-dev += "dev-elf"
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_DEFAULT_DEPS = "1"
 

--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -42,6 +42,7 @@ FILES_${PN}-dev = " \
                 ${includedir}/soletta/* \
                 ${libdir}/pkgconfig/soletta.pc \
                 ${libdir}/soletta/modules/flow/* \
+                ${libdir}/soletta/modules/update/* \
                 ${libdir}/soletta/modules/pin-mux/* \
                 ${libdir}/soletta/modules/linux-micro/* \
                 ${libdir}/soletta/modules/flow-metatype/* \

--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -88,6 +88,12 @@ do_configure_prepend() {
    export TARGETAR="${AR}"
 }
 
+do_configure_append() {
+   # The RPATH should not be set otherwise it will set the path of the host
+   # becoming invalid
+   # Also, yocto has a toolchain that will treat RPATH for Soletta
+   sed -i "s/^RPATH=y/# RPATH is not set/g" ${S}/.config
+}
 
 do_compile() {
    # changing the home directory to the working directory, the .npmrc will be created in this directory


### PR DESCRIPTION
This patch set fix:
- Installed vs shipped error for module  `linux-micro-efi-update.so`
- soletta-dev package contains non-symlink .so for all flow modules
- Invalid RPATH error.
