### PR TITLE
soletta: remove INHIBIT_PACKAGE_STRIP and INHIBIT_DEFAULT_DEPS

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -78,8 +78,6 @@ RDEPENDS_${PN} = " \
 # maybe an non-obvious implicit rule implied by yocto
 INSANE_SKIP_${PN} += "dev-deps file-rdeps"
 INSANE_SKIP_${PN}-dev += "dev-elf"
-INHIBIT_PACKAGE_STRIP = "1"
-INHIBIT_DEFAULT_DEPS = "1"
 
 B = "${WORKDIR}/git"
 


### PR DESCRIPTION
The INHIBIT_PACKAGE_STRIP causes the build to not strip Soletta's binaries and
this is not the desired behavior.

The INHIBIT_DEFAULT_DEPS prevents the default dependencies, namely the C
compiler and standard C library (libc), from being added to DEPENDS and also
this is not the desired behavior for the recipe.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
