### PR TITLE
soletta_git.bb: avoid node-gyp/Python3 incompatibility

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -108,6 +108,11 @@ do_compile() {
    export HOME=${WORKDIR}
    export LIBDIR="${libdir}/"
 
+   # Exported by python3native.bbclass as of OE-core c1e0eb62f2 and
+   # breaks compilation of node-gyp because gyp only works with
+   # Python2 (https://codereview.chromium.org/1454433002).
+   unset PYTHON
+
    # does not build dev packages
    npm config set dev false
 


### PR DESCRIPTION
python3native.bbclass started to export the PYTHON environment
variable in OE-core c1e0eb62f2. Compilation worked without that
before and now breaks in node-gyp, which checks the variable
and then aborts because gyp doesn't support Python3.

Unsetting the variable before compilation restores the previous
state and makes it possible to compile again.

This PR is important because it blocks Ostro's move to recent OE-core,
see https://github.com/ostroproject/ostro-os/pull/116
