### PR TITLE
soleta_git.bb: fix HOSTCC mess

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -87,6 +87,7 @@ B = "${WORKDIR}/git"
 
 do_configure_prepend() {
    export TARGETCC="${CC}"
+   export HOSTCC="${CC}"
    export TARGETAR="${AR}"
    export LIBDIR="${libdir}/"
 }


### PR DESCRIPTION
Should fix #97

Soletta was considering HOSTCC, if not set, should be composed
by (HOST_PREFIX)(CC).

Looks like in this case HOST_PREFIX = x86_64-ostro-linux- and
CC = x86_64-ostro-linux-gcc

So HOSTCC was wrong.

@bottazzini ptal ^

Signed-off-by: Bruno Dilly bruno.dilly@intel.com
