### PR TITLE
soleta_git.bb: fix HOSTCC mess

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -87,6 +87,7 @@ B = "${WORKDIR}/git"
 
 do_configure_prepend() {
    export TARGETCC="${CC}"
+   export HOSTCC="gcc"
    export TARGETAR="${AR}"
    export LIBDIR="${libdir}/"
 }


### PR DESCRIPTION
Should fix #97

Changelog from V1:
  explicitly set gcc since CC is x86_64-ostro-linux-gcc

Signed-off-by: Bruno Dilly bruno.dilly@intel.com
