### PR TITLE
make sure libpcre is built with utf enabled

### DIFF
--- a/recipes-configure/libpcre/libpcre_%.bbappend
+++ b/recipes-configure/libpcre/libpcre_%.bbappend
@@ -1,0 +1,9 @@
+# libpcre_%.bbappend
+#
+# Configure to build with proper suppot to utf-8, required
+# by Soletta's string node types.
+
+EXTRA_OECONF += "\
+    --enable-utf \
+    --enable-unicode-properties \
+"


### PR DESCRIPTION
Tentative solution to make test
string-pcre-regexp-search.fbp stop failing.

It seems correct on oe-core already...

Signed-off-by: Bruno Dilly bruno.dilly@intel.com
