### PR TITLE
soletta: fix GNU_HASH QA Error

### DIFF
--- a/recipes-soletta/soletta/soletta_git.bb
+++ b/recipes-soletta/soletta/soletta_git.bb
@@ -105,6 +105,9 @@ do_configure_append() {
        sed -i -e 's/^ *FLOW_NODE_TYPE_GTK=.*/# FLOW_NODE_TYPE_GTK is not set/g' ${S}/.config
    fi
 
+   sed -i "s/^\(CONFIG_LDFLAGS=\).*/\1\"${LDFLAGS}\"/g" ${S}/.config
+
+   oe_runmake oldconfig
 }
 
 do_compile() {


### PR DESCRIPTION
do_package_qa (insane.bbclass) checks for hash-style in ELF binaries.
It wants to see GNU_HASH and gives an error if it's not found.

With soletta, the bitbake LDFLAGS are not passed to Kconfig so
hash-style remains unchanged and we see a QA error.

Fix the error by passing the ${TARGET_LDFLAGS} via CONFIG_LDFLAGS
in .config. In addition, re-run oe_runmake oldconfig in
do_configure_append to ensure all config changes are correctly
propagated.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
