### PR TITLE
dev-app:avahi: Do not hardcode network link

### DIFF
--- a/recipes-soletta/dev-app/soletta-dev-app/soletta-dev-app-mac.sh
+++ b/recipes-soletta/dev-app/soletta-dev-app/soletta-dev-app-mac.sh
@@ -1,4 +1,3 @@
 #! /bin/bash
-INTERFACE="enp2s0"
-MAC_ADDRESS=`ifconfig $INTERFACE | grep "HWaddr" | awk '{print $NF}'`
+MAC_ADDRESS=`ip addr show scope global | grep "link/ether" -m 1 | awk  -F' ' '{print $2}'`
 sed -i "s@MACADDR@$MAC_ADDRESS@" /etc/avahi/services/soletta-dev-app.service


### PR DESCRIPTION
Get the macaddress from the first network link (scope global) instead of
hardcode a link that can not even exist.

Signed-off-by: Flavio Ceolin flavio.ceolin@intel.com
