### PR TITLE
dev-app:avahi: Do not hardcode network link

### DIFF
--- a/recipes-soletta/dev-app/soletta-dev-app/soletta-dev-app-mac.sh
+++ b/recipes-soletta/dev-app/soletta-dev-app/soletta-dev-app-mac.sh
@@ -1,4 +1,3 @@
 #! /bin/bash
-INTERFACE="enp2s0"
-MAC_ADDRESS=`ifconfig $INTERFACE | grep "HWaddr" | awk '{print $NF}'`
+MAC_ADDRESS=`ifconfig INTERFACE | grep "HWaddr" | awk '{print $NF}'`
 sed -i "s@MACADDR@$MAC_ADDRESS@" /etc/avahi/services/soletta-dev-app.service

--- a/recipes-soletta/dev-app/soletta-dev-app_git.bb
+++ b/recipes-soletta/dev-app/soletta-dev-app_git.bb
@@ -37,6 +37,8 @@ FILES_${PN} += " \
 
 SYSTEMD_SERVICE_${PN} = "soletta-dev-app-server.service soletta-dev-app-avahi-discover.service"
 
+SOLETTA_DEVAPP_INTERFACE ?= "enp2s0"
+
 do_install() {
   install -d ${D}{INSTALLATION_PATH}
   install -d ${D}${INSTALLATION_PATH}soletta-dev-app
@@ -58,4 +60,5 @@ do_install() {
 
  #Install set MAC address script
  install  -m 0755 ${WORKDIR}/soletta-dev-app-mac.sh ${D}${INSTALLATION_PATH}soletta-dev-app/scripts/
+ sed -i -e 's/INTERFACE/${SOLETTA_DEVAPP_INTERFACE}/g' ${D}${INSTALLATION_PATH}soletta-dev-app/scripts/soletta-dev-app-mac.sh
 }


### PR DESCRIPTION
Get the macaddress from the first network link (real device) instead of
hardcode a link that can not even exist.

Signed-off-by: Flavio Ceolin flavio.ceolin@intel.com
