### PR TITLE
Use bb.utils.contains instead of base_contains

### DIFF
--- a/recipes-modules/libmicrohttpd/libmicrohttpd_0.9.49.bb
+++ b/recipes-modules/libmicrohttpd/libmicrohttpd_0.9.49.bb
@@ -16,7 +16,7 @@ EXTRA_OECONF += "--disable-static --with-gnutls=${STAGING_LIBDIR}/../ --disable-
 
 PACKAGECONFIG ?= "curl"
 PACKAGECONFIG_append_class-target = "\
-        ${@base_contains('DISTRO_FEATURES', 'largefile', 'largefile', '', d)} \
+        ${@bb.utils.contains('DISTRO_FEATURES', 'largefile', 'largefile', '', d)} \
 "
 PACKAGECONFIG[largefile] = "--enable-largefile,--disable-largefile,,"
 PACKAGECONFIG[curl] = "--enable-curl,--disable-curl,curl,"


### PR DESCRIPTION
base_contains is deprecated.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>