### PR TITLE
jsonschema: enable SSL support

### DIFF
--- a/recipes-modules/jsonschema/python3-jsonschema.inc~
+++ b/recipes-modules/jsonschema/python3-jsonschema.inc~
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=7a60a81c146ec25599a3e1dabb8610a8"
 PR = "r0"
 SRCNAME = "jsonschema"
 
-SRC_URI = "https://pypi.python.org/packages/source/j/${SRCNAME}/${SRCNAME}-${PV}.zip"
+SRC_URI = "http://pypi.python.org/packages/source/j/${SRCNAME}/${SRCNAME}-${PV}.zip"
 
 SRC_URI[md5sum] = "f645c88123189976058fcf550c02e50f"
 SRC_URI[sha256sum] = "acf1e360b4682d64ba6acc35dbc65d81d9bde68a291a97f14f16f4282733f5a4"


### PR DESCRIPTION
This patch changes the download link to use SSL.
The default link now defaults to use SSL.

Signed-off-by: Sit Wei Hong <michael.wei.hong.sit@intel.com>